### PR TITLE
Minor

### DIFF
--- a/src/main/java/com/faojen/exoterra/blocks/machine/crystalcatalyst/CrystalCatalystScreen.java
+++ b/src/main/java/com/faojen/exoterra/blocks/machine/crystalcatalyst/CrystalCatalystScreen.java
@@ -58,7 +58,7 @@ public class CrystalCatalystScreen extends AbstractContainerScreen<CrystalCataly
 		}
 
 		// Stellar Display
-		ScreenUtils.drawVerticalMeter(this.container.getMaxCapacity(), this.container.getFluidStored(), this, stack, 49, 142, 29, 176, 129, 23, leftPos, topPos);
+		ScreenUtils.drawVerticalMeter(CrystalCatalystBE.FLUID_CAP_PUB, this.container.getFluidStored(), this, stack, 49, 142, 29, 176, 129, 23, leftPos, topPos);
 			
 		}
 

--- a/src/main/java/com/faojen/exoterra/blocks/machine/purificationbestower/PurificationBestowerBE.java
+++ b/src/main/java/com/faojen/exoterra/blocks/machine/purificationbestower/PurificationBestowerBE.java
@@ -137,7 +137,7 @@ public class PurificationBestowerBE extends BlockEntity implements MenuProvider 
 		FluidStack fluidpoke = new FluidStack(Registration.AQUEOUS_STELLAR.get(), 1);
 
 		this.getCapability(CapabilityEnergy.ENERGY).ifPresent(energyStorage -> {
-			boolean canPurifyStellar = fluidStorage.fill(fluidpoke, FluidAction.SIMULATE) >0;
+			boolean canPurifyStellar = fluidStorage.getCapacity() > 0;
 			
 			if (scounter > 0 && canPurifyStellar) {
 				purify(fluidStorage);

--- a/src/main/java/com/faojen/exoterra/blocks/machine/stellaraccumulator/StellarAccumulatorScreen.java
+++ b/src/main/java/com/faojen/exoterra/blocks/machine/stellaraccumulator/StellarAccumulatorScreen.java
@@ -49,13 +49,14 @@ public class StellarAccumulatorScreen extends AbstractContainerScreen<StellarAcc
 
         // Power Display
         if (this.container.getEnergy() > 0) {
-            ScreenUtils.drawVerticalMeter(this.container.getMaxPower(),this.container.getEnergy(),this, stack,52, 9, 26, 177, 71, 14, leftPos, topPos);
+            ScreenUtils.drawVerticalMeter(StellarAccumulatorBE.ENERGY_CAPACITY_PUB,this.container.getEnergy(),this, stack,52, 9, 26, 177, 71, 14, leftPos, topPos);
         }
         // Sludge Display
         if(this.container.getFluidStored() > 0){
-            ScreenUtils.drawVerticalMeter(this.container.getMaxFluid(), this.container.getFluidStored(), this, stack, 52, 30, 25, 177, 124, 38, leftPos, topPos);
+            ScreenUtils.drawVerticalMeter(StellarAccumulatorBE.FLUID_CAP_PUB, this.container.getFluidStored(), this, stack, 52, 30, 25, 177, 124, 38, leftPos, topPos);
         }
 
+        // Filter Progress
         if (this.container.getFilterProgress() > 0) {
             ScreenUtils.drawHorizontalMeter(512,this.container.getFilterProgress(), this, stack, 79, 72, 24, 176, 1, 18, leftPos, topPos);
         }

--- a/src/main/java/com/faojen/exoterra/blocks/simple/superiorpowerbank/SuperiorPowerBankScreen.java
+++ b/src/main/java/com/faojen/exoterra/blocks/simple/superiorpowerbank/SuperiorPowerBankScreen.java
@@ -2,6 +2,7 @@ package com.faojen.exoterra.blocks.simple.superiorpowerbank;
 
 import com.faojen.exoterra.ExoTerra;
 import com.faojen.exoterra.api.generic.ScreenUtils;
+import com.faojen.exoterra.blocks.machine.purificationbestower.PurificationBestowerBE;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
@@ -46,7 +47,7 @@ public class SuperiorPowerBankScreen extends AbstractContainerScreen<SuperiorPow
 
 		// Power Display
 		if (this.container.getEnergy() > 0) {
-			ScreenUtils.drawHorizontalMeter(this.container.getMaxPower(), this.container.getEnergy(), this, stack, 158, 9, 26, 0, 166, 53, leftPos, topPos);
+			ScreenUtils.drawHorizontalMeter(PurificationBestowerBE.ENERGY_CAPACITY_PUB, this.container.getEnergy(), this, stack, 158, 9, 26, 0, 166, 53, leftPos, topPos);
 		}
 
 		// Draw power meter corners


### PR DESCRIPTION
CryCatScreen: changed capacity get for the meter to return a more static value in case of server-client desync
PurBestBE: changed action validity check to check for the capacity of the tank instead of simulating a fill, which broke when the tank was already full.
StellAccuScreen: Changed all capacity gets to more static values in case of server-client desync.
SupPowScreen: changed capacity get to static value.